### PR TITLE
'progress' -> $percent is a float now

### DIFF
--- a/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
+++ b/src/FFMpeg/Format/ProgressListener/AbstractProgressListener.php
@@ -199,7 +199,7 @@ abstract class AbstractProgressListener extends EventEmitter implements Listener
 
         $percent = $percent / $this->totalPass + ($this->currentPass - 1) / $this->totalPass;
 
-        $this->percent = floor($percent * 100);
+        $this->percent = round($percent * 100, 2, PHP_ROUND_HALF_DOWN);
         $this->lastOutput = $currentTime;
         $this->currentSize = (int) $currentSize;
         $this->currentTime = $currentDuration;


### PR DESCRIPTION
Float for progress - better granularity and indication of state especially for long running transcoders