### PR TITLE
Support for PHP 8.4 (#933)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-20.04]
-                php: [8.3, 8.2, 8.1, 8.0]
+                php: [8.4, 8.3, 8.2, 8.1, 8.0]
                 ffmpeg: [5.0, 4.4]
                 dependency-version: [prefer-lowest, prefer-stable]
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,8 +8,8 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-20.04]
-                php: [8.4, 8.3, 8.2, 8.1, 8.0]
+                os: [ubuntu-24.04]
+                php: [8.5, 8.4, 8.3, 8.2, 8.1, 8.0]
                 ffmpeg: [5.0, 4.4]
                 dependency-version: [prefer-lowest, prefer-stable]
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -37,7 +37,7 @@ jobs:
                   composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             - name: Cache dependencies
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: ~/.composer/cache/files
                   key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}-dep-${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3",
+        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
         "evenement/evenement": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "spatie/temporary-directory": "^2.0",
@@ -57,7 +57,7 @@
         "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.10",
+        "phpunit/phpunit": "^9.5.10 || ^10.0",
         "mockery/mockery": "^1.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -46,12 +46,12 @@
         }
     ],
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
+        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4 || ^8.5",
         "evenement/evenement": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "spatie/temporary-directory": "^2.0",
-        "symfony/process": "^5.4 || ^6.0 || ^7.0",
-        "symfony/cache": "^5.4 || ^6.0 || ^7.0"
+        "symfony/process": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0 || ^8.0"
     },
     "suggest": {
         "php-ffmpeg/extras": "A compilation of common audio & video drivers for PHP-FFMpeg"

--- a/src/Alchemy/BinaryDriver/AbstractBinary.php
+++ b/src/Alchemy/BinaryDriver/AbstractBinary.php
@@ -139,7 +139,7 @@ abstract class AbstractBinary extends EventEmitter implements BinaryInterface
     /**
      * {@inheritdoc}
      */
-    public static function load($binaries, LoggerInterface $logger = null, $configuration = array())
+    public static function load($binaries, ?LoggerInterface $logger = null, $configuration = array())
     {
         $finder = new ExecutableFinder();
         $binary = null;

--- a/src/Alchemy/BinaryDriver/BinaryInterface.php
+++ b/src/Alchemy/BinaryDriver/BinaryInterface.php
@@ -63,5 +63,5 @@ interface BinaryInterface extends ConfigurationAwareInterface, ProcessBuilderFac
      *
      * @return BinaryInterface
      */
-    public static function load($binaries, LoggerInterface $logger = null, $configuration = array());
+    public static function load($binaries, ?LoggerInterface $logger = null, $configuration = array());
 }

--- a/src/Alchemy/BinaryDriver/Configuration.php
+++ b/src/Alchemy/BinaryDriver/Configuration.php
@@ -78,7 +78,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return $this->has($offset);
     }
@@ -86,7 +86,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset): mixed
+    public function offsetGet(mixed $offset): mixed
     {
         return $this->get($offset);
     }
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value): void
+    public function offsetSet(mixed $offset, $value): void
     {
         $this->set($offset, $value);
     }
@@ -102,7 +102,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function offsetUnset($offset): void
+    public function offsetUnset(mixed $offset): void
     {
         $this->remove($offset);
     }

--- a/src/Alchemy/BinaryDriver/ConfigurationInterface.php
+++ b/src/Alchemy/BinaryDriver/ConfigurationInterface.php
@@ -36,7 +36,7 @@ interface ConfigurationInterface extends \ArrayAccess, \IteratorAggregate
      *
      * @param string $key
      *
-     * @return Boolean
+     * @return boolean
      */
     public function has($key);
 

--- a/src/Alchemy/BinaryDriver/Listeners/Listeners.php
+++ b/src/Alchemy/BinaryDriver/Listeners/Listeners.php
@@ -30,7 +30,7 @@ class Listeners extends EventEmitter
      *
      * @return ListenersInterface
      */
-    public function register(ListenerInterface $listener, EventEmitter $target = null)
+    public function register(ListenerInterface $listener, ?EventEmitter $target = null)
     {
         $EElisteners = array();
 

--- a/src/Alchemy/BinaryDriver/ProcessRunner.php
+++ b/src/Alchemy/BinaryDriver/ProcessRunner.php
@@ -88,7 +88,7 @@ class ProcessRunner implements ProcessRunnerInterface
         };
     }
 
-    private function doExecutionFailure($command, $errorOutput, \Exception $e = null)
+    private function doExecutionFailure($command, $errorOutput, ?\Exception $e = null)
     {
         $this->logger->error($this->createErrorMessage($command, $errorOutput));
         throw new ExecutionFailureException(

--- a/src/FFMpeg/Driver/FFMpegDriver.php
+++ b/src/FFMpeg/Driver/FFMpegDriver.php
@@ -37,7 +37,7 @@ class FFMpegDriver extends AbstractBinary
      *
      * @return FFMpegDriver
      */
-    public static function create(LoggerInterface $logger = null, $configuration = [])
+    public static function create(?LoggerInterface $logger = null, $configuration = [])
     {
         if (!$configuration instanceof ConfigurationInterface) {
             $configuration = new Configuration($configuration);

--- a/src/FFMpeg/Driver/FFMpegDriver.php
+++ b/src/FFMpeg/Driver/FFMpegDriver.php
@@ -23,6 +23,8 @@ class FFMpegDriver extends AbstractBinary
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getName()
     {

--- a/src/FFMpeg/Driver/FFProbeDriver.php
+++ b/src/FFMpeg/Driver/FFProbeDriver.php
@@ -36,7 +36,7 @@ class FFProbeDriver extends AbstractBinary
      *
      * @return FFProbeDriver
      */
-    public static function create($configuration, LoggerInterface $logger = null)
+    public static function create($configuration, ?LoggerInterface $logger = null)
     {
         if (!$configuration instanceof ConfigurationInterface) {
             $configuration = new Configuration($configuration);

--- a/src/FFMpeg/Driver/FFProbeDriver.php
+++ b/src/FFMpeg/Driver/FFProbeDriver.php
@@ -22,6 +22,8 @@ class FFProbeDriver extends AbstractBinary
 {
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function getName()
     {

--- a/src/FFMpeg/FFMpeg.php
+++ b/src/FFMpeg/FFMpeg.php
@@ -124,7 +124,7 @@ class FFMpeg
      *
      * @return FFMpeg
      */
-    public static function create($configuration = [], LoggerInterface $logger = null, FFProbe $probe = null)
+    public static function create($configuration = [], ?LoggerInterface $logger = null, ?FFProbe $probe = null)
     {
         if (null === $probe) {
             $probe = FFProbe::create($configuration, $logger, null);

--- a/src/FFMpeg/FFProbe.php
+++ b/src/FFMpeg/FFProbe.php
@@ -211,7 +211,7 @@ class FFProbe
      *
      * @return FFProbe
      */
-    public static function create($configuration = [], LoggerInterface $logger = null, CacheItemPoolInterface $cache = null)
+    public static function create($configuration = [], ?LoggerInterface $logger = null, ?CacheItemPoolInterface $cache = null)
     {
         if (null === $cache) {
             $cache = new ArrayAdapter();

--- a/src/FFMpeg/Filters/Audio/AudioClipFilter.php
+++ b/src/FFMpeg/Filters/Audio/AudioClipFilter.php
@@ -32,7 +32,7 @@ class AudioClipFilter implements AudioFilterInterface
      */
     private $priority;
 
-    public function __construct(TimeCode $start, TimeCode $duration = null, $priority = 0)
+    public function __construct(TimeCode $start, ?TimeCode $duration = null, $priority = 0)
     {
         $this->start = $start;
         $this->duration = $duration;

--- a/src/FFMpeg/Filters/Video/ClipFilter.php
+++ b/src/FFMpeg/Filters/Video/ClipFilter.php
@@ -24,7 +24,7 @@ class ClipFilter implements VideoFilterInterface
     /** @var int */
     private $priority;
 
-    public function __construct(TimeCode $start, TimeCode $duration = null, $priority = 0)
+    public function __construct(TimeCode $start, ?TimeCode $duration = null, $priority = 0)
     {
         $this->start = $start;
         $this->duration = $duration;

--- a/src/FFMpeg/Media/Clip.php
+++ b/src/FFMpeg/Media/Clip.php
@@ -23,7 +23,7 @@ class Clip extends Video
     /** @var Video Parrent video */
     private $video;
 
-    public function __construct(Video $video, FFMpegDriver $driver, FFProbe $ffprobe, TimeCode $start, TimeCode $duration = null)
+    public function __construct(Video $video, FFMpegDriver $driver, FFProbe $ffprobe, TimeCode $start, ?TimeCode $duration = null)
     {
         $this->start = $start;
         $this->duration = $duration;

--- a/src/FFMpeg/Media/Video.php
+++ b/src/FFMpeg/Media/Video.php
@@ -58,7 +58,7 @@ class Video extends AbstractVideo
      *
      * @return \FFMpeg\Media\Clip
      */
-    public function clip(TimeCode $start, TimeCode $duration = null)
+    public function clip(TimeCode $start, ?TimeCode $duration = null)
     {
         return new Clip($this, $this->driver, $this->ffprobe, $start, $duration);
     }

--- a/tests/Alchemy/BinaryDriver/AbstractProcessBuilderFactoryTrait.php
+++ b/tests/Alchemy/BinaryDriver/AbstractProcessBuilderFactoryTrait.php
@@ -7,7 +7,7 @@ use Alchemy\BinaryDriver\ProcessBuilderFactory;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\ExecutableFinder;
 
-abstract class AbstractProcessBuilderFactoryTest extends TestCase
+trait AbstractProcessBuilderFactoryTrait
 {
     public static $phpBinary;
 

--- a/tests/Alchemy/BinaryDriver/LTSProcessBuilderFactoryTest.php
+++ b/tests/Alchemy/BinaryDriver/LTSProcessBuilderFactoryTest.php
@@ -3,9 +3,13 @@
 namespace Alchemy\Tests\BinaryDriver;
 
 use Alchemy\BinaryDriver\ProcessBuilderFactory;
+use Alchemy\Tests\BinaryDriver\AbstractProcessBuilderFactoryTrait;
+use Tests\FFMpeg\Unit\TestCase;
 
-class LTSProcessBuilderFactoryTest extends AbstractProcessBuilderFactoryTest
+class LTSProcessBuilderFactoryTest extends TestCase
 {
+    use AbstractProcessBuilderFactoryTrait;
+
     public function setUp(): void
     {
         if (!class_exists('Symfony\Component\Process\ProcessBuilder')) {

--- a/tests/Alchemy/BinaryDriver/NONLTSProcessBuilderFactoryTest.php
+++ b/tests/Alchemy/BinaryDriver/NONLTSProcessBuilderFactoryTest.php
@@ -3,9 +3,13 @@
 namespace Alchemy\Tests\BinaryDriver;
 
 use Alchemy\BinaryDriver\ProcessBuilderFactory;
+use Alchemy\Tests\BinaryDriver\AbstractProcessBuilderFactoryTrait;
+use Tests\FFMpeg\Unit\TestCase;
 
-class NONLTSProcessBuilderFactoryTest extends AbstractProcessBuilderFactoryTest
+class NONLTSProcessBuilderFactoryTest extends TestCase
 {
+    use AbstractProcessBuilderFactoryTrait;
+
     protected function getProcessBuilderFactory($binary)
     {
         ProcessBuilderFactory::$emulateSfLTS = true;

--- a/tests/FFMpeg/Functional/FFProbeTest.php
+++ b/tests/FFMpeg/Functional/FFProbeTest.php
@@ -34,6 +34,8 @@ class FFProbeTest extends FunctionalTestCase
 
     public function testProbeOnRemoteFile()
     {
+        $this->markTestSkipped('Remote file access is disabled for now.');
+
         $ffprobe = FFProbe::create();
         $this->assertGreaterThan(0, count($ffprobe->streams('http://vjs.zencdn.net/v/oceans.mp4')));
     }


### PR DESCRIPTION
# Pull latest from PHP-FFMPEG master to Radical's fork

* Add PHP 8.4 to test matrix
* Refactored `AbstractProcessBuilderFactoryTest` to trait

Expands test support for 8.4, no breaking changes to core functionality